### PR TITLE
Adding v3.5 GGUF information and links

### DIFF
--- a/models/download_models.md
+++ b/models/download_models.md
@@ -9,7 +9,7 @@ SEA-LION models are available for download via the following channels:
 | Model                | Download   |
 |----------------------|------------|
 | Llama-SEA-LION-v3.5-8B-R      | [HuggingFace](https://huggingface.co/aisingapore/Llama-SEA-LION-v3.5-8B-R) |
-| Llama-SEA-LION-v3.5-8B-R-GGUF | _coming soon_ |
+| Llama-SEA-LION-v3.5-8B-R-GGUF | [HuggingFace](https://huggingface.co/aisingapore/Llama-SEA-LION-v3.5-8B-R-GGUF), [Ollama](https://ollama.com/aisingapore/Llama-SEA-LION-v3.5-8B-R) |
 
 <br>
 
@@ -17,7 +17,7 @@ SEA-LION models are available for download via the following channels:
 | Model                | Download   |
 |----------------------|------------|
 | Llama-SEA-LION-v3.5-70B-R    | [HuggingFace](https://huggingface.co/aisingapore/Llama-SEA-LION-v3.5-70B-R)      |
-| Llama-SEA-LION-v3.5-70B-R-GGUF | _coming soon_ |
+| Llama-SEA-LION-v3.5-70B-R-GGUF | [HuggingFace](https://huggingface.co/aisingapore/Llama-SEA-LION-v3.5-70B-R-GGUF), [Ollama](https://ollama.com/aisingapore/Llama-SEA-LION-v3.5-70B-R) |
 
 
 ## SEA-LION v3

--- a/models/sea-lion-v3.5/llama-sea-lion-v3.5-70B.md
+++ b/models/sea-lion-v3.5/llama-sea-lion-v3.5-70B.md
@@ -15,7 +15,7 @@ At a glance:
 - **Context Length**: 128K 
 - **Available Formats**:
   - Reasoning (Llama-SEA-LION-v3.5-70B-R)
-  - GGUF (Llama-SEA-LION-v3.5-70B-R-GGUF) _`coming soon`_
+  - GGUF (Llama-SEA-LION-v3.5-70B-R-GGUF)
 - **Supported Languages:** 
   1. Burmese
   2. Chinese
@@ -75,7 +75,20 @@ For more details on Llama-SEA-LION-v3.5-70B-R benchmark performance, please refe
 
 ## Llama-SEA-LION-v3.5-70B-R-GGUF
 
-_TO be available soon_ 
+The following quantized GGUF formats of our Llama-SEA-LION-v3.5-70B-R model are available:
+- Llama-SEA-LION-v3.5-70B-R-F16
+- Llama-SEA-LION-v3.5-70B-R-Q2_K
+- Llama-SEA-LION-v3.5-70B-R-Q3_K_M
+- Llama-SEA-LION-v3.5-70B-R-Q4_0
+- Llama-SEA-LION-v3.5-70B-R-Q4_K_M
+- Llama-SEA-LION-v3.5-70B-R-Q5_0
+- Llama-SEA-LION-v3.5-70B-R-Q5_K_M
+- Llama-SEA-LION-v3.5-70B-R-Q6_K
+- Llama-SEA-LION-v3.5-70B-R-Q8_0
+
+Please refer to our [Download the Model(s)](#download-the-model-s) section for more details on how to access them.
+
+<br>
 
 ## Download the Model(s)
 Llama-SEA-LION-v3.5-70B-R models are available for download via the following channels:
@@ -86,7 +99,7 @@ Llama-SEA-LION-v3.5-70B-R models are available for download via the following ch
 | Model                | Download   |
 |----------------------|------------|
 | Llama-SEA-LION-v3.5-70B-R           | [HuggingFace](https://huggingface.co/aisingapore/Llama-SEA-LION-v3.5-70B-R), [Kaggle]()      |
-| Llama-SEA-LION-v3.5-70B-R-GGUF | _coming soon_ |
+| Llama-SEA-LION-v3.5-70B-R-GGUF | [HuggingFace](https://huggingface.co/aisingapore/Llama-SEA-LION-v3.5-70B-R-GGUF), [Ollama](https://ollama.com/aisingapore/Llama-SEA-LION-v3.5-70B-R) |
 
 <br>
 

--- a/models/sea-lion-v3.5/llama-sea-lion-v3.5-70B.md
+++ b/models/sea-lion-v3.5/llama-sea-lion-v3.5-70B.md
@@ -98,7 +98,7 @@ Llama-SEA-LION-v3.5-70B-R models are available for download via the following ch
 
 | Model                | Download   |
 |----------------------|------------|
-| Llama-SEA-LION-v3.5-70B-R           | [HuggingFace](https://huggingface.co/aisingapore/Llama-SEA-LION-v3.5-70B-R), [Kaggle]()      |
+| Llama-SEA-LION-v3.5-70B-R           | [HuggingFace](https://huggingface.co/aisingapore/Llama-SEA-LION-v3.5-70B-R)     |
 | Llama-SEA-LION-v3.5-70B-R-GGUF | [HuggingFace](https://huggingface.co/aisingapore/Llama-SEA-LION-v3.5-70B-R-GGUF), [Ollama](https://ollama.com/aisingapore/Llama-SEA-LION-v3.5-70B-R) |
 
 <br>

--- a/models/sea-lion-v3.5/llama-sea-lion-v3.5-8B.md
+++ b/models/sea-lion-v3.5/llama-sea-lion-v3.5-8B.md
@@ -15,7 +15,7 @@ At a glance:
 - **Context Length**: 128K 
 - **Available Formats**:
   - Reasoning (Llama-SEA-LION-v3.5-8B-R)
-  - GGUF (Llama-SEA-LION-v3.5-8B-R-GGUF) _`coming soon`_
+  - GGUF (Llama-SEA-LION-v3.5-8B-R-GGUF)
 - **Supported Languages:** 
   1. Burmese
   2. Chinese
@@ -76,7 +76,20 @@ For more details on Llama-SEA-LION-v3.5-8B-R benchmark performance, please refer
 
 ## Llama-SEA-LION-v3.5-8B-R-GGUF
 
-_TO be available soon_ 
+The following quantized GGUF formats of our Llama-SEA-LION-v3.5-8B-R model are available:
+- Llama-SEA-LION-v3.5-8B-R-F16
+- Llama-SEA-LION-v3.5-8B-R-Q2_K
+- Llama-SEA-LION-v3.5-8B-R-Q3_K_M
+- Llama-SEA-LION-v3.5-8B-R-Q4_0
+- Llama-SEA-LION-v3.5-8B-R-Q4_K_M
+- Llama-SEA-LION-v3.5-8B-R-Q5_0
+- Llama-SEA-LION-v3.5-8B-R-Q5_K_M
+- Llama-SEA-LION-v3.5-8B-R-Q6_K
+- Llama-SEA-LION-v3.5-8B-R-Q8_0
+
+Please refer to our [Download the Model(s)](#download-the-model-s) section for more details on how to access them.
+
+<br>
 
 ## Download the Model(s)
 Llama-SEA-LION-v3.5-8B-R models are available for download via the following channels:
@@ -87,7 +100,7 @@ Llama-SEA-LION-v3.5-8B-R models are available for download via the following cha
 | Model                | Download   |
 |----------------------|------------|
 | Llama-SEA-LION-v3.5-8B-R           | [HuggingFace](https://huggingface.co/aisingapore/Llama-SEA-LION-v3.5-8B-R)      |
-| Llama-SEA-LION-v3.5-8B-R-GGUF | _coming soon_ |
+| Llama-SEA-LION-v3.5-8B-R-GGUF | [HuggingFace](https://huggingface.co/aisingapore/Llama-SEA-LION-v3.5-8B-R-GGUF), [Ollama](https://ollama.com/aisingapore/Llama-SEA-LION-v3.5-8B-R) |
 
 <br>
 


### PR DESCRIPTION
GGUF versions of v3.5 SEA-LION models have been generated on HF and Ollama. This PR adds the respective links to the documentation